### PR TITLE
Fix compilation on Windows

### DIFF
--- a/cmake/FindEigen3.cmake
+++ b/cmake/FindEigen3.cmake
@@ -9,6 +9,12 @@
 #  EIGEN3_FOUND - system has eigen lib with correct version
 #  EIGEN3_INCLUDE_DIR - the eigen include directory
 #  EIGEN3_VERSION - eigen version
+#
+# This module reads hints about search locations from 
+# the following enviroment variables:
+#
+# EIGEN3_ROOT
+# EIGEN3_ROOT_DIR
 
 # Copyright (c) 2006, 2007 Montel Laurent, <montel@kde.org>
 # Copyright (c) 2008, 2009 Gael Guennebaud, <g.gael@free.fr>
@@ -62,6 +68,9 @@ if (EIGEN3_INCLUDE_DIR)
 else (EIGEN3_INCLUDE_DIR)
 
   find_path(EIGEN3_INCLUDE_DIR NAMES signature_of_eigen3_matrix_library
+      HINTS
+      ENV EIGEN3_ROOT 
+      ENV EIGEN3_ROOT_DIR
       PATHS
       ${CMAKE_INSTALL_PREFIX}/include
       ${KDE4_INCLUDE_DIR}

--- a/mex-wholebodymodel/library/src/modelgetstate.cpp
+++ b/mex-wholebodymodel/library/src/modelgetstate.cpp
@@ -26,7 +26,6 @@
 
 // local includes
 #include "modelgetstate.h"
-#include <boost/concept_check.hpp>
 
 using namespace mexWBIComponent;
 
@@ -170,7 +169,7 @@ bool ModelGetState::computeFast(int nrhs, const mxArray* prhs[])
 
   (modelState->getRootWorldRotoTranslation()).R.getQuaternion(rootQuaternion[1], rootQuaternion[2], rootQuaternion[3], rootQuaternion[0]);
 #ifdef DEBUG
- 
+
       std::stringstream ssR;
     ssR<<"Quat : ["<<rootQuaternion[0]<<","<<rootQuaternion[1]<<","<<rootQuaternion[2]<<","<<rootQuaternion[3]<<"]\n";
     std::string sR = ssR.str();

--- a/mex-wholebodymodel/library/src/modeljointlimits.cpp
+++ b/mex-wholebodymodel/library/src/modeljointlimits.cpp
@@ -86,34 +86,15 @@ bool ModelJointLimits::compute(int nrhs, const mxArray *prhs[])
    mexPrintf("Trying to compute ModelJointLimits\n");
 #endif
   robotModel = modelState->robotModel();
-  int numDof = modelState->dof();
-
-
-  double temp1[numDof],temp2[numDof];
-  robotModel->getJointLimits(temp1,temp2);
-
-  for(int i = 0; i<numDof; i++)
-  {
-      jointLowerLimit[i] = temp1[i];
-      jointUpperLimit[i] = temp2[i];
-  }
+  robotModel->getJointLimits(jointLowerLimit,jointUpperLimit);
 
   return(true);
 }
 
 bool ModelJointLimits::computeFast(int, const mxArray*[])
 {
-  int numDof = modelState->dof();
-
-  double temp1[numDof],temp2[numDof];
   robotModel = modelState->robotModel();
-  robotModel->getJointLimits(temp1,temp2);
-
-  for(int i = 0; i<numDof; i++)
-  {
-      jointLowerLimit[i] = temp1[i];
-      jointUpperLimit[i] = temp2[i];
-  }
+  robotModel->getJointLimits(jointLowerLimit,jointUpperLimit);
 
   return(true);
 }

--- a/tests/kinEnergyConservationTestAllModels.m
+++ b/tests/kinEnergyConservationTestAllModels.m
@@ -4,7 +4,7 @@
 fprintf('Running kinEnergyConservation\n');
 
 % plot the kinematic energy ?
-params.plot = true;
+params.plot = false;
 
 % raise error on fail ? Normally true, useful to turn it to false for debug
 params.raiseErrorOnFail = true;


### PR DESCRIPTION
Fix https://github.com/robotology/mex-wholebodymodel/issues/68

Mainly removing an unnecessary header and remove use of Variable Length Arrays, that are non-standard extension of C++ . 

For some reason I got a strange failure at the end of the tests, but I don't know if it is related. 

@gabrielenava can you briefly try this branch and check that the getjointlimits function is working correctly, and the test is running for you? Thanks! 

cc @S-Dafarra